### PR TITLE
Solution for request bundle during deployment

### DIFF
--- a/openshift/containers/sync2jira/Dockerfile
+++ b/openshift/containers/sync2jira/Dockerfile
@@ -44,4 +44,5 @@ RUN mkdir -p /usr/local/src \
 
 USER 1001
 
+ENTRYPOINT ["/usr/local/bin/openshift/containers/sync2jira/docker-entrypoint.sh"]
 CMD ["/usr/local/bin/sync2jira"]

--- a/openshift/containers/sync2jira/docker-entrypoint.sh
+++ b/openshift/containers/sync2jira/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+	#!/bin/bash
+set -e
+
+# CA_URL is the URL of a custom root CA certificate to be installed at run-time
+: ${CA_URL:=}
+
+main() {
+  # installing CA certificate
+  if [ -n "${CA_URL}" ] && [ ! -f "/tmp/.ca-imported" ]; then
+    # Since update-ca-trust doesn't work as a non-root user, let's just append to the bundle directly
+    curl --silent --show-error --location "${CA_URL}" >> /etc/pki/tls/certs/ca-bundle.crt
+    # Create a file so we know not to import it again if the container is restarted
+    touch /tmp/.ca-imported
+  fi
+}
+
+main
+exec "$@


### PR DESCRIPTION
We had the issue where we needed to do the equivalent of this: `export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.trust.crt`