### PR TITLE
Fix path to docker-entrypoint in Dockerfile

### DIFF
--- a/openshift/containers/sync2jira/Dockerfile
+++ b/openshift/containers/sync2jira/Dockerfile
@@ -44,5 +44,5 @@ RUN mkdir -p /usr/local/src \
 
 USER 1001
 
-ENTRYPOINT ["/usr/local/bin/openshift/containers/sync2jira/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/src/sync2jira/openshift/containers/sync2jira/docker-entrypoint.sh"]
 CMD ["/usr/local/bin/sync2jira"]


### PR DESCRIPTION
Path to docker-entrypoint.sh was incorrect. 