### PR TITLE
Update jinja FileSystemLoader path to be consistent with docker path

### DIFF
--- a/sync2jira/downstream.py
+++ b/sync2jira/downstream.py
@@ -280,7 +280,7 @@ def alert_user_of_duplicate_issues(issue, final_result, results_of_query,
         admin_template.append({'name': ret[0].displayName, 'email': ret[0].emailAddress})
 
     # Create and send email
-    templateLoader = jinja2.FileSystemLoader(searchpath='sync2jira/')
+    templateLoader = jinja2.FileSystemLoader(searchpath='usr/local/src/sync2jira/')
     templateEnv = jinja2.Environment(loader=templateLoader)
     template = templateEnv.get_template('email_template.jinja')
     html_text = template.render(user=user,

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -241,7 +241,7 @@ def report_failure(config):
     :param Dict config: Config dict for JIRA
     """
     # Email our admins with the traceback
-    templateLoader = jinja2.FileSystemLoader(searchpath='sync2jira/')
+    templateLoader = jinja2.FileSystemLoader(searchpath='usr/local/src/sync2jira')
     templateEnv = jinja2.Environment(loader=templateLoader)
     template = templateEnv.get_template('failure_template.jinja')
     html_text = template.render(traceback=traceback.format_exc())


### PR DESCRIPTION
Email templates were unable to be found because the jinja path was not consistent with the docker path. 