### PR TITLE
Add fail_under to coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ source = sync2jira/
 
 [report]
 omit = sync2jira/mailer.py
+fail_under = 70


### PR DESCRIPTION
Currently, coveralls will fail if the coverage goes down no matter what. But lets set it to 70% and only fail if it's under that. 