### PR TITLE
Remove version requirement for coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pypandoc
 urllib3
 jinja2
 python-coveralls
-coverage==5.0.1
+coverage


### PR DESCRIPTION
Specifying coverage requirement caused openshift errors, remove that requirement. 