### PR TITLE
Separate test req and sync2jira req files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN dnf -y install \
     python3-pygithub \
     python3-jinja2 \
     python3-pypandoc \
-    python3-coverage \
-    python3-coveralls \
   && dnf -y clean all
 
 ARG SYNC2JIRA_GIT_REPO=https://github.com/sidpremkumar/Sync2Jira.git

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -16,8 +16,6 @@ RUN dnf -y install \
     python3-pygithub \
     python3-jinja2 \
     python3-pypandoc \
-    python3-coverage \
-    python3-coveralls \
   && dnf -y clean all
 
 ARG SYNC2JIRA_GIT_REPO=https://github.com/sidpremkumar/Sync2Jira.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.md
 include fedmsg.d/sync2jira.py
 include requirements.txt
+include test-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ PyGithub
 pypandoc
 urllib3
 jinja2
-python-coveralls
-coverage

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ from setuptools import setup
 with open('requirements.txt', 'rb') as f:
     install_requires = f.read().decode('utf-8').split('\n')
 
+with open('test-requirements.txt', 'rb') as f:
+    test_requires = f.read().decode('utf-8').split('\n')
 
 setup(
     name='sync2jira',
@@ -39,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     install_requires=install_requires,
+    tests_require=test_requires,
     test_suite='nose.collector',
     packages=[
         'sync2jira',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+python-coveralls
+coverage
+nose
+pytest
+pytest-cov
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,7 @@ basepython =
     py37: python3.7
 deps =
     -r{toxinidir}/requirements.txt
-    nose
-    pytest
-    pytest-cov
-    mock
+    -r{toxinidir}/test-requirements.txt
 sitepackages = False
 commands =
     coverage run -m pytest {posargs} --ignore=tests/integration_tests


### PR DESCRIPTION
We keep having a dependency issue in OpenShift due to test requirements being mixed with sync2jira requirements. This attempts to separate them. 