### PR TITLE
Add check when handling messages to confirm issue/pr is in sync array

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1125,7 +1125,7 @@ def sync_with_jira(issue, config):
     :returns: Nothing
     """
 
-    log.info("Considering upstream %s, %s", issue.url, issue.title)
+    log.info("[Issue] Considering upstream %s, %s", issue.url, issue.title)
 
     # Create a client connection for this issue
     client = get_jira_client(issue, config)

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -95,7 +95,7 @@ def sync_with_jira(pr, config):
     :param Dict config: Config dict
     :returns: Nothing
     """
-    log.info("Considering upstream %s, %s", pr.url, pr.title)
+    log.info("[PR] Considering upstream %s, %s", pr.url, pr.title)
 
     # Create a client connection for this issue
     client = d_issue.get_jira_client(pr, config)

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -161,11 +161,10 @@ def listen(config):
 
         issue = None
         pr = None
-
         # Github '.issue.' is used for both PR and Issue
         # Check for that edge case
         if suffix == 'github.issue.comment':
-            if 'pull_request' in msg['msg']['issue']:
+            if 'pull_request' in msg['msg']['issue'] and msg['msg']['action'] != 'deleted':
                 # pr_filter turns on/off the filtering of PRs
                 pr = issue_handlers[suffix](msg, config, pr_filter=False)
                 if not pr:

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -52,7 +52,10 @@ def handle_github_message(msg, config, pr_filter=True):
     mapped_repos = config['sync2jira']['map']['github']
 
     if upstream not in mapped_repos:
-        log.debug("%r not in github map: %r", upstream, mapped_repos.keys())
+        log.debug("%r not in Github map: %r", upstream, mapped_repos.keys())
+        return None
+    elif 'issue' not in mapped_repos[upstream]['sync']:
+        log.debug("%r not in Github issue map: %r", upstream, mapped_repos.keys())
         return None
 
     _filter = config['sync2jira']\
@@ -155,7 +158,10 @@ def handle_pagure_message(msg, config):
     mapped_repos = config['sync2jira']['map']['pagure']
 
     if upstream not in mapped_repos:
-        log.debug("%r not in pagure map: %r", upstream, mapped_repos.keys())
+        log.debug("%r not in Pagure map: %r", upstream, mapped_repos.keys())
+        return None
+    elif 'issue' not in mapped_repos[upstream]['sync']:
+        log.debug("%r not in Pagure issue map: %r", upstream, mapped_repos.keys())
         return None
 
     _filter = config['sync2jira']\

--- a/sync2jira/upstream_pr.py
+++ b/sync2jira/upstream_pr.py
@@ -55,7 +55,10 @@ def handle_pagure_message(msg, config, suffix):
 
     # Check if we should sync this PR
     if upstream not in mapped_repos:
-        log.debug("%r not in pagure map: %r", upstream, mapped_repos.keys())
+        log.debug("%r not in Pagure map: %r", upstream, mapped_repos.keys())
+        return None
+    elif 'pullrequest' not in mapped_repos[upstream]['sync']:
+        log.debug("%r not in Pagure PR map: %r", upstream, mapped_repos.keys())
         return None
 
     # Format the assignee field to match github (i.e. in a list)
@@ -93,7 +96,10 @@ def handle_github_message(msg, config, suffix):
     # Check if upstream is in mapped repos
     mapped_repos = config['sync2jira']['map']['github']
     if upstream not in mapped_repos:
-        log.debug("%r not in github map: %r", upstream, mapped_repos.keys())
+        log.debug("%r not in Github map: %r", upstream, mapped_repos.keys())
+        return None
+    elif 'pullrequest' not in mapped_repos[upstream]['sync']:
+        log.debug("%r not in Github PR map: %r", upstream, mapped_repos.keys())
         return None
 
     # Initialize Github object so we can get their full name (instead of their username)

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -22,10 +22,10 @@ class TestUpstreamIssue(unittest.TestCase):
             'sync2jira': {
                 'map': {
                     'github': {
-                        'org/repo': {},
+                        'org/repo': {'sync': ['issue']},
                     },
                     'pagure': {
-                        'org/repo': {},
+                        'org/repo': {'sync': ['issue']},
                     },
                 },
                 'jira': {

--- a/tests/test_upstream_pr.py
+++ b/tests/test_upstream_pr.py
@@ -22,10 +22,10 @@ class TestUpstreamPR(unittest.TestCase):
             'sync2jira': {
                 'map': {
                     'github': {
-                        'org/repo': {},
+                        'org/repo': {'sync': ['pullrequest']},
                     },
                     'pagure': {
-                        'org/repo': {},
+                        'org/repo': {'sync': ['pullrequest']},
                     },
                 },
                 'jira': {


### PR DESCRIPTION
When handling a message, ensure that pullrequest and/or sync is in the `sync` array. 