### PR TITLE
Update PR log to be consistent with issue logging

### DIFF
--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -97,6 +97,10 @@ def sync_with_jira(pr, config):
     """
     log.info("[PR] Considering upstream %s, %s", pr.url, pr.title)
 
+    if not pr.match:
+        log.info(f"[PR] No match found for {pr.title}")
+        return None
+
     # Create a client connection for this issue
     client = d_issue.get_jira_client(pr, config)
 

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -231,10 +231,6 @@ class PR(object):
         # Match a JIRA
         match = matcher(pr.get('initial_comment'), comments)
 
-        # If there is no JIRA return None
-        if not match:
-            return None
-
         # Return our PR object
         return PR(
             source=upstream_source,
@@ -279,10 +275,6 @@ class PR(object):
 
         # Match to a JIRA
         match = matcher(pr.get("body"), comments)
-
-        # If there is no JIRA return None
-        if not match:
-            return None
 
         # Figure out what state we're transitioning too
         if 'reopened' in suffix:


### PR DESCRIPTION
In Issue logging, we log when an issue doesn't have a match, update the PR logging to do the same. 