### PR TITLE
Add match attribute to issue objects that are related to PRs

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -36,6 +36,7 @@ import sync2jira.upstream_pr as u_pr
 import sync2jira.downstream_issue as d_issue
 import sync2jira.downstream_pr as d_pr
 from sync2jira.mailer import send_mail
+from sync2jira.intermediary import matcher
 
 # Set up our logging
 FORMAT = "[%(asctime)s] %(levelname)s: %(message)s"
@@ -172,6 +173,7 @@ def listen(config):
                 # Issues do not have suffix and reporter needs to be reformatted
                 pr.suffix = suffix
                 pr.reporter = pr.reporter.get('fullname')
+                setattr(pr, 'match', matcher(pr.content, pr.comments))
             else:
                 issue = issue_handlers[suffix](msg, config)
         elif suffix in issue_handlers:

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -54,8 +54,11 @@ def handle_github_message(msg, config, pr_filter=True):
     if upstream not in mapped_repos:
         log.debug("%r not in Github map: %r", upstream, mapped_repos.keys())
         return None
-    elif 'issue' not in mapped_repos[upstream]['sync']:
-        log.debug("%r not in Github issue map: %r", upstream, mapped_repos.keys())
+    elif 'issue' not in mapped_repos[upstream]['sync'] and pr_filter is True:
+        log.debug("%r not in Github Issue map: %r", upstream, mapped_repos.keys())
+        return None
+    elif 'pullrequest' not in mapped_repos[upstream]['sync'] and pr_filter is False:
+        log.debug("%r not in Github PR map: %r", upstream, mapped_repos.keys())
         return None
 
     _filter = config['sync2jira']\


### PR DESCRIPTION
Add match attribute to issue objects, and add some conditions around upstream_issue to ensure that when pr_filter is false, we check for `pullrequest` instead of `issue`