### PR TITLE
Create fully updated description when originally creating issue

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -569,6 +569,11 @@ def _create_jira_issue(client, issue, config):
     else:
         description = ''
 
+    if any('transition' in item for item in issue.downstream.get('updates', {})):
+        # Just add it to the top of the description
+        formatted_status = "Upstream issue status: %s" % issue.status
+        description = formatted_status + '\n' + description
+
     if issue.reporter:
         # Add to the description
         description = '[%s] Upstream Reporter: %s \n %s' % (

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -353,7 +353,7 @@ class TestDownstreamIssue(unittest.TestCase):
             issuetype={'name': 'Fix'},
             project={'key': 'mock_project'},
             somecustumfield='somecustumvalue',
-            description='[1234] Upstream Reporter: mock_user \n Upstream description: {quote}mock_content{quote}',
+            description='[1234] Upstream Reporter: mock_user \n Upstream issue status: Open\nUpstream description: {quote}mock_content{quote}',
             summary='mock_title'
         )
         mock_attach_link.assert_called_with(


### PR DESCRIPTION
We would double update an issue if we had to add transition information. This PR fixes that. 

Relates to JIRA: DEVOPSA-7069