### PR TITLE
Add confluence stat support

### DIFF
--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -43,6 +43,26 @@ The config file is made up of multiple parts
 
 .. code-block:: python
 
+    'confluence_statistics': False
+
+* Adds the ability to post statistics to confluence. See note below.
+
+.. note:: Optional: Confluence Statistic Support
+
+    a. What is it? If :code:`confluence_statistics` is set to `True` in the config file (default `False`) you can set up a Confluence page and space to post statistic too (i.e. how many comments synced etc)
+
+    b. Set up the following variables:
+        1. :code:`CONFLUENCE_SPACE` :: The Confluence space we're posting too
+        2. :code:`CONFLUENCE_PAGE_TITLE` :: The Confluence page we're posting too
+        3. :code:`CONFLUENCE_URL` :: The Confluence URL
+        4. :code:`CONFLUENCE_USERNAME` :: Confluence username data
+        5. :code:`CONFLUENCE_PASSWORD` :: Confluence password data
+
+    c. Create the related confluence page and space. Make sure to add the template (use :code:`sync2jira/confluence_stat.jinja` and replace the JINJA code with 0's
+
+
+.. code-block:: python
+
     'jira': {
         'example': {
             'options': {

--- a/docs/source/confluence_client.rst
+++ b/docs/source/confluence_client.rst
@@ -1,0 +1,8 @@
+Confluence Client
+=================
+
+.. automodule:: sync2jira.confluence_client
+    :members:
+    :private-members:
+
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,3 +28,4 @@ Sync2Jira documentation
    downstream_issue
    intermediary
    mailer
+   confluence_client

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -68,4 +68,3 @@ Want to quickly get started working with Sync2Jira? Follow these steps:
         sync2jira
     .. note:: You might have to add `config['validate_signatures'] = False`. 
               You can find out more under the `main <main.html#main-anchor>`_.
-

--- a/fedmsg.d/sync2jira.py
+++ b/fedmsg.d/sync2jira.py
@@ -37,6 +37,9 @@ config = {
         # Your Github token
         'github_token': 'YOUR_TOKEN',
 
+        # If we should update a Confluence page for stats
+        'confluence_statistics': False
+
         'legacy_matching': False,
 
         'default_jira_instance': 'example',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyGithub
 pypandoc
 urllib3
 jinja2
+requests_kerberos

--- a/sync2jira/confluence_client.py
+++ b/sync2jira/confluence_client.py
@@ -1,0 +1,236 @@
+#!/usr/bin/python3
+"""
+This script acts as a client to confluence, connects to confluence and create
+pages
+"""
+import os
+import re
+import requests
+from requests.auth import HTTPBasicAuth
+import jinja2
+import datetime
+
+
+class ConfluenceClient:
+
+    """ A conflence component used to connect to confluence and perform
+    confluence related tasks
+    """
+
+    def __init__(
+        self,
+        confluence_space=os.environ.get("CONFLUENCE_SPACE"),
+        confluence_page_title=os.environ.get("CONFLUENCE_PAGE_TITLE"),
+        confluence_url=os.environ.get("CONFLUENCE_URL"),
+        username=os.environ.get("CONFLUENCE_USERNAME"),
+        password=os.environ.get("CONFLUENCE_PASSWORD"),
+        auth_type="basic",
+    ):
+        """ Returns confluence client object
+        :param string confluence_space : space to be used in confluence
+        :param string confluence_page_title : Title of page to be created in
+        confluence
+        :param string confluence_url : url to connect confluence
+        :param string username : optional username for basic auth
+        :param string password : optional password for basic auth
+        :param string auth_type : indicate auth scheme (basic/kerberos)
+        """
+        self.confluence_space = confluence_space
+        self.confluence_page_title = confluence_page_title
+        self.confluence_url = confluence_url
+        self.confluence_rest_url = self.confluence_url + "/rest/api/content/"
+        self.username = username
+        self.password = password
+        self.authtype = auth_type
+        self.update_stat = False
+        self._req_kwargs = None
+
+        # Find our page ID and save it
+        resp = self.find_page()
+        if not resp:
+            raise ValueError("Invalid page name")
+        self.page_id = resp
+
+    def update_stat_value(self, new_value):
+        """ Update the 'update_stat' attribute.
+        :param Bool new_value: Bool value
+        """
+        self.update_stat = new_value
+
+    @property
+    def req_kwargs(self):
+        """ Set the key-word arguments for python-requests depending on the
+        auth type. This code should run on demand exactly once, which is
+        why it is a property.
+        :return dict _req_kwargs: dict with the right options to pass in
+        """
+        if self._req_kwargs is None:
+            if self.authtype == "basic":
+                self._req_kwargs = {"auth": self.get_auth_object()}
+        return self._req_kwargs
+
+    def update_stat_page(self, confluence_data):
+        """
+        Updates the statistic page with more data
+        :param dict confluence_data: Variable amount of new data
+        """
+        # Get the HTML to update
+        page_info = self.get_page_info(self.page_id)
+        page_html = page_info['body']['storage']['value']
+        # Maintain and update our final data
+        confluence_data_update = {
+            'Created Issues': 0,
+            'Descriptions': 0,
+            'Comments': 0,
+            'Reporters': 0,
+            'Status': 0,
+            'Assignees': 0,
+            'Transitions': 0,
+            'Title': 0,
+            'Tags': 0,
+            'FixVersion': 0,
+            'Misc. Fields': 0,
+            'Total': 0
+        }
+        confluence_data_times = {
+            'Created Issues': 60,
+            'Descriptions': 30,
+            'Comments': 30,
+            'Reporters': 30,
+            'Assignees': 15,
+            'Status': 30,
+            'Transitions': 30,
+            'Title': 15,
+            'Tags': 10,
+            'FixVersion': 10,
+            'Misc. Fields': 15,
+        }
+        # Use these HTML patterns to search for previous values
+        confluence_html_patterns = {
+            'Created Issues': "Created Issues&nbsp;</td><td>",
+            'Descriptions': "Descriptions</td><td>",
+            'Comments': "Comments</td><td>",
+            'Reporters': "Reporters</td><td>",
+            'Assignees': "Assignees</td><td>",
+            'Status': "Status</td><td>",
+            'Transitions': "Transitions</td><td>",
+            'Title': "Titles</td><td>",
+            'Tags': "Tags</td><td>",
+            'FixVersion': "Fix Version</td><td>",
+            'Misc. Fields': "Misc. Fields</td><td>",
+        }
+        # Update all our data
+        total = 0
+        for topic, html in confluence_html_patterns.items():
+            # Search for previous data
+            ret = re.search(html, page_html)
+            start_index = ret.span()[1]
+            new_val = ""
+            while page_html[start_index] != "<":
+                new_val += page_html[start_index]
+                start_index += 1
+            confluence_data_update[topic] = int(new_val)
+            total += int(new_val)
+
+        # Now add new data
+        for topic in confluence_html_patterns.keys():
+            if topic in confluence_data:
+                confluence_data_update[topic] += confluence_data[topic]
+                total += confluence_data[topic]
+        confluence_data_update["Total"] = total
+
+        # Calculate Total Time
+        total_time = 0
+        for topic in confluence_data_times.keys():
+            total_time += confluence_data_update[topic] * confluence_data_times[topic]
+        total_time = datetime.timedelta(seconds=total_time)
+        confluence_data_update["Total Time"] = str(total_time) + " (HR:MIN:SEC)"
+
+        # Build our updated HTML page
+        # templateLoader = jinja2.FileSystemLoader(
+        #     searchpath='usr/local/src/sync2jira/sync2jira/')
+        templateLoader = jinja2.FileSystemLoader(
+            searchpath='sync2jira/')
+        templateEnv = jinja2.Environment(loader=templateLoader)
+        template = templateEnv.get_template('confluence_stat.jinja')
+        html_text = template.render(confluence_data=confluence_data_update)
+
+        # Finally update our page
+        if html_text.replace(" ", "") != page_html.replace(" ", ""):
+            self.update_page(self.page_id, html_text)
+
+    def find_page(self):
+        """ finds the page with confluence_page_title in confluence_space
+        return string page_id : id of the page if found, otherwise None
+        """
+        search_url = (
+            self.confluence_url
+            + "/rest/api/content/search?cql=title='"
+            + self.confluence_page_title
+            + "' and "
+            + "space="
+            + self.confluence_space
+        )
+        resp = requests.get(search_url, **self.req_kwargs)
+        resp.raise_for_status()
+        if len(resp.json()["results"]) > 0:
+            return resp.json()["results"][0].get("id", None)
+        else:
+            return None
+
+    def get_page_info(self, page_id):
+        """Gives information like ancestors,version of a  page
+        :param string page_id: id of the confluence page
+        :return json conf_resp: response from the confluence
+        """
+        conf_rest_url = (
+            self.confluence_url
+            + "/rest/api/content/"
+            + page_id
+            + "?expand=ancestors,version,body.storage"
+        )
+        resp = requests.get(conf_rest_url, **self.req_kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_page(self, page_id, html_str):
+        """
+        Updates the page with id page_id
+        :param string page_id: id  of the page
+        :param string html_str : html_str content of the page
+        :return json conf_resp: response from the confluence
+        """
+        rest_url = self.confluence_rest_url + page_id
+        info = self.get_page_info(page_id)
+        updated_page_version = int(info["version"]["number"] + 1)
+
+        data = {
+            "id": str(page_id),
+            "type": "page",
+            "title": info["title"],
+            "version": {"number": updated_page_version},
+            "body": {"storage": {"representation": "storage", "value": html_str}},
+        }
+        resp = requests.put(rest_url, json=data, **self.req_kwargs)
+        if not resp.ok:
+            print("Confluence response: \n", resp.json())
+
+        resp.raise_for_status()
+
+        return resp.json()
+
+    def get_auth_object(self):
+        """Returns Auth object based on auth type
+        :return : Auth Object
+        """
+        if self.authtype == "basic":
+            return HTTPBasicAuth(self.username, self.password)
+
+
+if os.environ.get('CONFLUENCE_SPACE') != 'mock_confluence_space':
+    confluence_client = ConfluenceClient()
+else:
+    # Else we are testing, and create a mock_client
+    class mock_confluence_client(object):
+        mock_data = False
+    confluence_client = mock_confluence_client()

--- a/sync2jira/confluence_stat.jinja
+++ b/sync2jira/confluence_stat.jinja
@@ -1,0 +1,55 @@
+<p class="auto-cursor-target">
+    <br />
+</p>
+<table class="relative-table" style="width: 29.9457%;">
+    <colgroup><col style="width: 32.9091%;" />
+        <col style="width: 30.5455%;" />
+        <col style="width: 36.5455%;" />
+    </colgroup>
+    <tbody>
+            <tr>
+                <th>Type of Sync</th>
+                <th>Number of Syncs</th>
+                <th colspan="1">Avg. Time (Seconds)</th>
+            </tr>
+            <tr>
+                <td>Created Issues&nbsp;</td><td>{{ confluence_data['Created Issues'] }}</td><td colspan="1">60</td>
+            </tr>
+            <tr>
+                <td>Descriptions</td><td>{{ confluence_data['Descriptions'] }}</td><td colspan="1">30</td>
+            </tr>
+            <tr>
+                <td>Comments</td><td>{{ confluence_data['Comments'] }}</td><td colspan="1">30</td>
+            </tr>
+            <tr>
+                <td>Reporters</td><td>{{ confluence_data['Reporters'] }}</td><td colspan="1">30</td>
+            </tr>
+            <tr>
+                <td>Assignees</td><td>{{ confluence_data['Assignees'] }}</td><td colspan="1">15</td>
+            </tr>
+            <tr>
+                <td>Status</td><td>{{ confluence_data['Status'] }}</td><td colspan="1">30</td>
+            </tr>
+            <tr>
+                <td>Transitions</td><td>{{ confluence_data['Transitions'] }}</td><td colspan="1">30</td>
+            </tr>
+            <tr>
+                <td>Titles</td><td>{{ confluence_data['Title'] }}</td><td colspan="1">15</td>
+            </tr>
+            <tr>
+                <td>Tags</td><td>{{ confluence_data['Tags'] }}</td><td colspan="1">5</td>
+            </tr>
+            <tr>
+                <td>Fix Version</td><td>{{ confluence_data['FixVersion'] }}</td><td colspan="1">5</td>
+            </tr>
+            <tr>
+                <td>Misc. Fields</td><td>{{ confluence_data['Misc. Fields'] }}</td><td colspan="1">15</td>
+            </tr>
+            <tr>
+                <td colspan="1"><strong>Total</strong></td><td colspan="1"><strong>{{ confluence_data['Total'] }}</strong></td><td colspan="1"><strong>{{ confluence_data['Total Time'] }}</strong></td>
+            </tr>
+    </tbody>
+</table>
+<p class="auto-cursor-target">
+    <br />
+</p>

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -25,6 +25,7 @@ from jira import JIRAError
 # Local Modules
 import sync2jira.downstream_issue as d_issue
 from sync2jira.intermediary import Issue, matcher
+from sync2jira.confluence_client import confluence_client
 
 
 log = logging.getLogger(__name__)
@@ -101,6 +102,9 @@ def update_jira_issue(existing, pr, client):
     if not exists:
         log.info(f"Added comment for PR {pr.title} on JIRA {pr.jira_key}")
         client.add_comment(existing, new_comment)
+        if confluence_client.update_stat:
+            confluence_data = {'Comments': 1}
+            confluence_client.update_stat_page(confluence_data)
 
     # Only synchronize link_transition for listings that op-in
     if any('merge_transition' in item for item in updates) and 'merged' in pr.suffix:

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -21,22 +21,25 @@
 
 Run with systemd, please.
 """
-
+# Build-In Modules
 import logging
 import warnings
 import traceback
 from time import sleep
 
+# 3rd Party Modules
 import fedmsg
 import fedmsg.config
 import jinja2
 
+# Local Modules
 import sync2jira.upstream_issue as u_issue
 import sync2jira.upstream_pr as u_pr
 import sync2jira.downstream_issue as d_issue
 import sync2jira.downstream_pr as d_pr
 from sync2jira.mailer import send_mail
 from sync2jira.intermediary import matcher
+from sync2jira.confluence_client import confluence_client
 
 # Set up our logging
 FORMAT = "[%(asctime)s] %(levelname)s: %(message)s"
@@ -307,6 +310,9 @@ def main(runtime_test=False, runtime_config=None):
         config = load_config()
     else:
         config = runtime_config
+
+    if config['sync2jira']['confluence_statistics']:
+        confluence_client.update_stat_value(True)
 
     logging.basicConfig(level=logging.INFO)
     warnings.simplefilter("ignore")

--- a/tests/test_confluence_client.py
+++ b/tests/test_confluence_client.py
@@ -1,0 +1,318 @@
+import unittest
+
+import mock
+
+try:
+    # Python 3.3 >
+    from unittest.mock import MagicMock  # noqa: F401
+except ImportError:
+    from mock import MagicMock  # noqa: F401
+
+PATH = 'sync2jira.confluence_client.'
+
+from sync2jira.confluence_client import ConfluenceClient
+
+
+class TestConfluenceClient(unittest.TestCase):
+    """
+    This class tests the confluence_client.py file
+    """
+
+    @mock.patch(PATH + 'ConfluenceClient.find_page')
+    def setUp(self,
+              mock_find_page):
+        mock_find_page.return_value = "mock_page_id"
+        self.confluence_client = ConfluenceClient()
+
+        self.mock_resp_bad = MagicMock()
+        self.mock_resp_bad.raise_for_status.side_effect = ValueError()
+        self.mock_resp_bad.ok = False
+
+    def test_update_state_value(self):
+        """
+        This function tests the 'update_stat_value' function
+        """
+        # Call the function
+        self.confluence_client.update_stat_value(True)
+
+        # Assert Everything was called correctly
+        self.assertEqual(self.confluence_client.update_stat, True)
+
+    @mock.patch(PATH + 'ConfluenceClient.get_auth_object')
+    @mock.patch(PATH + 'requests')
+    def test_req_kwargs_basic(self,
+                              mock_requests,
+                              mock_get_auth_object):
+        """
+        This function tests 'req_kwargs' property with a basic client
+        """
+        # Set up return values
+        mock_get_auth_object.return_value = 'mock_auth_object'
+
+        # Call the function
+        response = self.confluence_client.req_kwargs
+
+        # Assert everything was called correctly
+        mock_requests.get.assert_not_called()
+        mock_get_auth_object.assert_called()
+        self.assertEqual(response, {'auth': 'mock_auth_object'})
+
+    @mock.patch(PATH + 'requests')
+    @mock.patch(PATH + 'ConfluenceClient.req_kwargs')
+    def test_find_page_found(self,
+                             mock_req_kwargs,
+                             mock_requests):
+        """
+        This function tests the 'find_page' function where we find a page
+        """
+        # Set up return values
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'results': [{'id': 'mock_id'}]}
+        mock_requests.get.return_value = mock_resp
+
+        # Call the function
+        response = self.confluence_client.find_page()
+
+        # Assert everything was called correctly
+        mock_requests.get.assert_called_with(
+            "http://mock_confluence_url/rest/api/content/search?cql=title='mock_confluence_page_title' and space=mock_confluence_space")
+        mock_resp.raise_for_status.assert_called()
+        mock_resp.json.assert_called()
+        self.assertEqual(response, 'mock_id')
+
+    @mock.patch(PATH + 'requests')
+    @mock.patch(PATH + 'ConfluenceClient.req_kwargs')
+    def test_find_page_not_found(self,
+                                 mock_req_kwargs,
+                                 mock_requests):
+        """
+        This function tests the 'find_page' function where we don't find a page
+        """
+        # Set up return values
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'results': []}
+        mock_requests.get.return_value = mock_resp
+
+        # Call the function
+        response = self.confluence_client.find_page()
+
+        # Assert everything was called correctly
+        mock_requests.get.assert_called_with(
+            "http://mock_confluence_url/rest/api/content/search?cql=title='mock_confluence_page_title' and space=mock_confluence_space")
+        mock_resp.raise_for_status.assert_called()
+        mock_resp.json.assert_called()
+        self.assertEqual(response, None)
+
+    @mock.patch(PATH + 'requests')
+    @mock.patch(PATH + 'ConfluenceClient.req_kwargs')
+    def test_find_page_error(self,
+                             mock_req_kwargs,
+                             mock_requests):
+        """
+        This function tests the 'find_page' function where we get an Error
+        """
+        # Set up return values
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'results': []}
+        mock_requests.get.return_value = self.mock_resp_bad
+
+        # Call the function
+        with self.assertRaises(ValueError):
+            self.confluence_client.find_page()
+
+        # Assert everything was called correctly
+        mock_requests.get.assert_called_with(
+            "http://mock_confluence_url/rest/api/content/search?cql=title='mock_confluence_page_title' and space=mock_confluence_space")
+        self.mock_resp_bad.raise_for_status.assert_called()
+        self.mock_resp_bad.json.assert_not_called()
+
+    @mock.patch(PATH + 'requests')
+    @mock.patch(PATH + 'ConfluenceClient.req_kwargs')
+    def test_get_page_info(self,
+                           mock_req_kwargs,
+                           mock_requests):
+        """
+        This function tests the 'get_page_info' function where we have no Errors
+        """
+        # Set up return values
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = 'mock_json'
+        mock_requests.get.return_value = mock_resp
+
+        # Call the function
+        response = self.confluence_client.get_page_info('mock_page_id')
+
+        # Assert everything was called correctly
+        mock_requests.get.assert_called_with(
+            'http://mock_confluence_url/rest/api/content/mock_page_id?expand=ancestors,version,body.storage')
+        self.assertEqual(response, 'mock_json')
+        mock_resp.raise_for_status.assert_called()
+
+    @mock.patch(PATH + 'requests')
+    @mock.patch(PATH + 'ConfluenceClient.req_kwargs')
+    def test_get_page_info_error(self,
+                                 mock_req_kwargs,
+                                 mock_requests):
+        """
+        This function tests the 'get_page_info' function where we have Errors
+        """
+        # Set up return values
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = 'mock_json'
+        mock_requests.get.return_value = self.mock_resp_bad
+
+        # Call the function
+        with self.assertRaises(ValueError):
+            self.confluence_client.get_page_info('mock_page_id')
+
+        # Assert everything was called correctly
+        mock_requests.get.assert_called_with(
+            'http://mock_confluence_url/rest/api/content/mock_page_id?expand=ancestors,version,body.storage')
+        self.mock_resp_bad.raise_for_status.assert_called()
+
+    @mock.patch(PATH + 'ConfluenceClient.get_page_info')
+    @mock.patch(PATH + 'requests')
+    @mock.patch(PATH + 'ConfluenceClient.req_kwargs')
+    def test_update_page(self,
+                         mock_req_kwargs,
+                         mock_requests,
+                         mock_get_page_info):
+        """
+        This function tests the 'update_page' function where we have no Errors
+        """
+        # Set up return values
+        mock_get_page_info.return_value = {
+            'version': {'number': 1},
+            'title': 'mock_title'}
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = 'mock_json'
+        mock_requests.put.return_value = mock_resp
+
+        # Call the function
+        response = self.confluence_client.update_page(
+            page_id='mock_page_id',
+            html_str='mock_html_str',
+        )
+
+        # Assert everything was called correctly
+        mock_requests.put.assert_called_with(
+            'http://mock_confluence_url/rest/api/content/mock_page_id',
+            json={'id': 'mock_page_id', 'type': 'page',
+                  'title': 'mock_title', 'version': {'number': 2},
+                  'body': {'storage':
+                               {'representation': 'storage', 'value': 'mock_html_str'}}})
+        mock_resp.raise_for_status.assert_called()
+        self.assertEqual(response, 'mock_json')
+
+    @mock.patch(PATH + 'ConfluenceClient.get_page_info')
+    @mock.patch(PATH + 'requests')
+    @mock.patch(PATH + 'ConfluenceClient.req_kwargs')
+    def test_update_page_error(self,
+                               mock_req_kwargs,
+                               mock_requests,
+                               mock_get_page_info):
+        """
+        This function tests the 'update_page' function where we have Errors
+        """
+        # Set up return values
+        mock_get_page_info.return_value = {
+            'version': {'number': 1},
+            'title': 'mock_title'}
+        mock_requests.put.return_value = self.mock_resp_bad
+
+        # Call the function
+        with self.assertRaises(ValueError):
+            self.confluence_client.update_page(
+                page_id='mock_page_id',
+                html_str='mock_html_str',
+            )
+
+        # Assert everything was called correctly
+        mock_requests.put.assert_called_with(
+            'http://mock_confluence_url/rest/api/content/mock_page_id',
+            json={
+                'id': 'mock_page_id',
+                'type': 'page',
+                'title': 'mock_title',
+                'version': {'number': 2},
+                'body':
+                    {'storage': {'representation': 'storage', 'value': 'mock_html_str'}}})
+        self.mock_resp_bad.raise_for_status.assert_called()
+
+    @mock.patch(PATH + 'HTTPBasicAuth')
+    def test_get_auth_object_basic(self,
+                                   mock_basic,):
+        """
+        This function tests 'get_auth_object' with basic auth
+        """
+        # Set up return values
+        mock_basic.return_value = 'mock_basic_auth'
+
+        # Call the function
+        response = self.confluence_client.get_auth_object()
+
+        # Assert everything was called correctly
+        self.assertEqual(response, 'mock_basic_auth')
+        mock_basic.assert_called_with('mock_confluence_username', 'mock_confluence_password')
+
+    @mock.patch(PATH + 'ConfluenceClient.update_page')
+    @mock.patch(PATH + 'jinja2')
+    @mock.patch(PATH + 'ConfluenceClient.get_page_info')
+    def test_update_stat_page(self,
+                              mock_get_page_info,
+                              mock_jinja2,
+                              mock_update_page):
+        """
+        This function tests 'update_stat_page' function
+        """
+        # Set up return values
+        mock_html = """
+                        Created Issues&nbsp;</td><td>1<
+                        Descriptions</td><td>1<
+                        Comments</td><td>1<
+                        Reporters</td><td>1<
+                        Assignees</td><td>1<
+                        Status</td><td>1<
+                        Transitions</td><td>1<
+                        Titles</td><td>1<
+                        Tags</td><td>1<
+                        Fix Version</td><td>1<
+                        Misc. Fields</td><td>1<
+                        Total</strong></td><td colspan="1"><strong>1<
+                    """
+        mock_get_page_info.return_value = {'body': {'storage': {'value': mock_html}}}
+        mock_confluence_data = {
+            'Created Issues': 10,
+            'Descriptions': 10,
+            'Comments': 10,
+            'Reporters': 10,
+            'Status': 10,
+            'Assignees': 10,
+            'Transitions': 10,
+            'Title': 10,
+            'Tags': 10,
+            'FixVersion': 10,
+            'Misc. Fields': 10,
+        }
+        mock_templateLoader = MagicMock()
+        mock_templateEnv = MagicMock()
+        mock_template = MagicMock()
+        mock_template.render.return_value = 'mock_render'
+        mock_templateEnv.get_template.return_value = mock_template
+        mock_jinja2.FileSystemLoader.return_value = mock_templateLoader
+        mock_jinja2.Environment.return_value = mock_templateEnv
+
+        # Call the function
+        self.confluence_client.update_stat_page(mock_confluence_data)
+
+        # Assert Everything was called correctly
+        mock_jinja2.FileSystemLoader.assert_called_with(searchpath='sync2jira/')
+        mock_jinja2.Environment.assert_called_with(loader=mock_templateLoader)
+        mock_templateEnv.get_template.assert_called_with('confluence_stat.jinja')
+        mock_template.render.assert_called_with(confluence_data={
+            'Created Issues': 11, 'Descriptions': 11, 'Comments': 11,
+            'Reporters': 11, 'Status': 11, 'Assignees': 11, 'Transitions': 11,
+            'Title': 11, 'Tags': 11, 'FixVersion': 11, 'Misc. Fields': 11,
+            'Total': 121, 'Total Time': '0:50:25 (HR:MIN:SEC)'})
+        mock_update_page.assert_called_with('mock_page_id', 'mock_render')

--- a/tests/test_downstream_pr.py
+++ b/tests/test_downstream_pr.py
@@ -144,17 +144,20 @@ class TestDownstreamPR(unittest.TestCase):
         mock_client.search_issues.assert_not_called()
         mock_d_issue.get_jira_client.assert_not_called()
 
+    @mock.patch(PATH + 'confluence_client')
     @mock.patch(PATH + 'comment_exists')
     @mock.patch(PATH + 'format_comment')
     def test_update_jira_issue_link(self,
                                     mock_format_comment,
-                                    mock_comment_exists):
+                                    mock_comment_exists,
+                                    mock_confluence_client):
         """
         This function tests 'update_jira_issue'
         """
         # Set up return values
         mock_format_comment.return_value = 'mock_formatted_comment'
         mock_comment_exists.return_value = False
+        mock_confluence_client.update_stat = True
 
         # Call the function
         d.update_jira_issue('mock_existing', self.mock_pr, self.mock_client)
@@ -163,6 +166,7 @@ class TestDownstreamPR(unittest.TestCase):
         self.mock_client.add_comment.assert_called_with('mock_existing', 'mock_formatted_comment')
         mock_format_comment.assert_called_with(self.mock_pr, self.mock_pr.suffix, self.mock_client)
         mock_comment_exists.assert_called_with(self.mock_client, 'mock_existing', 'mock_formatted_comment')
+        mock_confluence_client.update_stat_page.assert_called_with({'Comments': 1})
 
 
     @mock.patch(PATH + 'comment_exists')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -141,6 +141,7 @@ class TestMain(unittest.TestCase):
         mock_u.pagure_issues.assert_called_with('key_pagure', self.mock_config)
         mock_u.github_issues.assert_called_with('key_github', self.mock_config)
 
+    @mock.patch(PATH + 'confluence_client')
     @mock.patch(PATH + 'initialize_issues')
     @mock.patch(PATH + 'initialize_pr')
     @mock.patch(PATH + 'load_config')
@@ -149,12 +150,14 @@ class TestMain(unittest.TestCase):
                   mock_listen,
                   mock_load_config,
                   mock_initialize_pr,
-                  mock_initialize_issues):
+                  mock_initialize_issues,
+                  mock_confluence_client):
         """
         This tests the 'main' function
         """
         # Set up return values
         mock_load_config.return_value = self.mock_config
+        self.mock_config['sync2jira']['confluence_statistics'] = True
 
         # Call the function
         m.main()
@@ -165,6 +168,7 @@ class TestMain(unittest.TestCase):
         mock_listen.assert_called_with(self.mock_config)
         mock_initialize_issues.assert_called_with(self.mock_config)
         mock_initialize_pr.assert_called_with(self.mock_config)
+        mock_confluence_client.update_stat_value.assert_called_with(True)
 
     @mock.patch(PATH + 'u_issue')
     @mock.patch(PATH + 'd_issue')

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ passenv = TRAVIS TRAVIS_*
 setenv =
     DEFAULT_FROM = mock_email@mock.com
     DEFAULT_SERVER = mock_server
+    CONFLUENCE_SPACE=mock_confluence_space
+    CONFLUENCE_PAGE_TITLE=mock_confluence_page_title
+    CONFLUENCE_URL=http://mock_confluence_url
+    CONFLUENCE_USERNAME=mock_confluence_username
+    CONFLUENCE_PASSWORD=mock_confluence_password
 basepython =
     py37: python3.7
 deps =
@@ -14,5 +19,4 @@ deps =
 sitepackages = False
 commands =
     coverage run -m pytest {posargs} --ignore=tests/integration_tests
-
 # Add the following line locally to get an HTML report --cov-report html:htmlcov-py37


### PR DESCRIPTION
Amoung this PR: 
- Update some of the old tests to capture more edge cases and ensure they are only *unit* tests
- Add the ability to push to confluence page with statistics of what is being synced. Also, generate approx unit time associated with syncing 
