### PR TITLE
Add mailing list support to send failure emails

### DIFF
--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -10,6 +10,12 @@ The config file is made up of multiple parts
 
 .. code-block:: python
 
+    'mailing-list': 'demo_email@demo.com'
+
+* Mailing list is used to alert users when there is a failure. A failure email with the traceback will be sent to the email address. 
+
+.. code-block:: python
+
     'initialize': True
 
 * Initialization set to True will ensure that there is an initial sync done when Sync2Jira starts.

--- a/fedmsg.d/sync2jira.py
+++ b/fedmsg.d/sync2jira.py
@@ -22,6 +22,9 @@ config = {
         # Admins to be cc'd in duplicate emails
         'admins': [{'admin_username': 'admin_email@demo.com'}],
 
+        # Mailing list email to send failure-email notices too
+        'mailing-list': 'some_email@demo.com',
+
         # Scrape sources at startup
         'initialize': True,
 

--- a/sync2jira/mailer.py
+++ b/sync2jira/mailer.py
@@ -36,6 +36,5 @@ def send_mail(recipients, subject, text, cc):
     server = smtplib.SMTP(_cfg["server"])
     part = MIMEText(text, 'html', 'utf-8')
     msg.attach(part)
-
     server.sendmail(sender, recipients, msg.as_string())
     server.quit()

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -345,13 +345,8 @@ def report_failure(config):
     template = templateEnv.get_template('failure_template.jinja')
     html_text = template.render(traceback=traceback.format_exc())
 
-    # Get admin information
-    admins = []
-    for admin in config['sync2jira']['admins']:
-        admins.extend([admin[name] for name in admin])
-
     # Send mail
-    send_mail(recipients=admins,
+    send_mail(recipients=[config['sync2jira']['mailing-list']],
               cc=None,
               subject=failure_email_subject,
               text=html_text)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -350,7 +350,7 @@ class TestMain(unittest.TestCase):
         mock_jinja2.Environment.return_value = mock_templateEnv
 
         # Call the function
-        m.report_failure({'sync2jira': {'admins': [{'mock_user': 'mock_email'}]}})
+        m.report_failure({'sync2jira': {'mailing-list': 'mock_email'}})
 
         # Assert everything was called correctly
         mock_send_mail.assert_called_with(cc=None,


### PR DESCRIPTION
Send failure emails to the mailing list instead of admins. 