### PR TITLE
Fix confluence HTML

### DIFF
--- a/sync2jira/confluence_client.py
+++ b/sync2jira/confluence_client.py
@@ -107,7 +107,7 @@ class ConfluenceClient:
         }
         # Use these HTML patterns to search for previous values
         confluence_html_patterns = {
-            'Created Issues': "Created Issues&nbsp;</td><td>",
+            'Created Issues': "Created Issues</td><td>",
             'Descriptions': "Descriptions</td><td>",
             'Comments': "Comments</td><td>",
             'Reporters': "Reporters</td><td>",

--- a/sync2jira/confluence_stat.jinja
+++ b/sync2jira/confluence_stat.jinja
@@ -13,7 +13,7 @@
                 <th colspan="1">Avg. Time (Seconds)</th>
             </tr>
             <tr>
-                <td>Created Issues&nbsp;</td><td>{{ confluence_data['Created Issues'] }}</td><td colspan="1">60</td>
+                <td>Created Issues</td><td>{{ confluence_data['Created Issues'] }}</td><td colspan="1">60</td>
             </tr>
             <tr>
                 <td>Descriptions</td><td>{{ confluence_data['Descriptions'] }}</td><td colspan="1">30</td>

--- a/tests/test_confluence_client.py
+++ b/tests/test_confluence_client.py
@@ -268,7 +268,7 @@ class TestConfluenceClient(unittest.TestCase):
         """
         # Set up return values
         mock_html = """
-                        Created Issues&nbsp;</td><td>1<
+                        Created Issues</td><td>1<
                         Descriptions</td><td>1<
                         Comments</td><td>1<
                         Reporters</td><td>1<


### PR DESCRIPTION
Confluence HTML had a weird `&nbsp;`. Removed that from the jinja template and from the parsing. 