### PR TITLE
Catch connection timeout error

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1034,7 +1034,7 @@ def _update_assignee(client, existing, issue, updates):
                 confluence_data = {'Assignee': 1}
                 confluence_client.update_stat_page(confluence_data)
         else:
-            if existing.fields.assignee and existing.fields.assignee.displayName != issue.assignee[0]['fullname']:
+            if existing.fields.assignee and not issue.assignee:
                 # Else we should remove all assignees
                 # Set removeAll flag to true
                 assign_user(client, issue, existing, remove_all=True)

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -88,7 +88,7 @@ def handle_github_message(msg, config, pr_filter=True):
 
     # Initialize Github object so we can get their full name (instead of their username)
     # And get comments if needed
-    github_client = Github(config['sync2jira']['github_token'])
+    github_client = Github(config['sync2jira']['github_token'], retry=5)
 
     # If there are no comments just make an empty array
     if msg['msg']['issue']['comments'] == 0:
@@ -294,7 +294,7 @@ def github_issues(upstream, config):
 
     # Initialize Github object so we can get their full name (instead of their username)
     # And get comments if needed
-    github_client = Github(config['sync2jira']['github_token'])
+    github_client = Github(config['sync2jira']['github_token'], retry=5)
 
     # We need to format everything to a standard to we can create an issue object
     final_issues = []

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -476,7 +476,7 @@ class TestUpstreamIssue(unittest.TestCase):
                                                    'user': {'login': 'mock_login', 'fullname': 'mock_name'},
                                                    'milestone': 'mock_milestone'},
                                                   self.mock_config)
-        mock_github.assert_called_with('mock_token')
+        mock_github.assert_called_with('mock_token', retry=5)
         self.assertEqual('Successful Call!', response)
         self.mock_github_client.get_repo.assert_not_called()
         self.mock_github_repo.get_issue.assert_not_called()
@@ -511,7 +511,7 @@ class TestUpstreamIssue(unittest.TestCase):
                                                    'filter1': 'filter1', 'user':
                                                        {'login': 'mock_login', 'fullname': 'mock_name'},
                                                    'milestone': 'mock_milestone'}, self.mock_config)
-        mock_github.assert_called_with('mock_token')
+        mock_github.assert_called_with('mock_token', retry=5)
         self.assertEqual('Successful Call!', response)
         self.mock_github_client.get_repo.assert_called_with('org/repo')
         self.mock_github_repo.get_issue.assert_called_with(number='mock_number')


### PR DESCRIPTION
Sync2Jira keeps failing due to a connection timeout with github. Apparently it does not actaully try to re-try it, it just tried it once and fails. When we get a connection timeout, we should wait, and re-sync whatever we were syncing. 

Also, fix a small assignee error

https://github.com/psf/requests/issues/1198
