### PR TITLE
Add conditional to saving log file

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -51,8 +51,10 @@ logging.basicConfig(format=FORMAT, level=logging.INFO)
 logging.basicConfig(format=FORMAT, level=logging.DEBUG)
 logging.basicConfig(format=FORMAT, level=logging.WARNING)
 log = logging.getLogger('sync2jira')
-hdlr = logging.FileHandler('sync2jira_main.log')
-log.addHandler(hdlr)
+if os.environ.get('CONFLUENCE_SPACE') == 'mock_confluence_space':
+    # If we are debugging save log output
+    hdlr = logging.FileHandler('sync2jira_main.log')
+    log.addHandler(hdlr)
 log.setLevel(logging.DEBUG)
 
 # Only allow fedmsg logs that are critical


### PR DESCRIPTION
When we are running stage/master, we don't want to save logs (we get permission errors because we are calling `sync2jira` from the root of the Docker container. 